### PR TITLE
Added 'throws SlackException' to call method

### DIFF
--- a/src/main/java/net/gpedro/integrations/slack/SlackApi.java
+++ b/src/main/java/net/gpedro/integrations/slack/SlackApi.java
@@ -57,7 +57,7 @@ public class SlackApi {
     /**
      * Prepare Message and send to Slack
      */
-    public void call(SlackMessage message) {
+    public void call(SlackMessage message) throws SlackException {
         if (message != null) {
             this.send(message.prepare());
         }


### PR DESCRIPTION
Wasn't aware the void method call could throw an exception until runtime when I got errors, due to a channel not being created.